### PR TITLE
Untitled

### DIFF
--- a/lib/sinatra/respond_to.rb
+++ b/lib/sinatra/respond_to.rb
@@ -149,7 +149,7 @@ module Sinatra
         klass.class_eval do
           alias :content_type_without_save :content_type
           def content_type(*args)
-            @_format = args.first.to_sym
+            @_format = (args.first ? args.first.to_sym : nil)
             content_type_without_save *args
           end
         end


### PR DESCRIPTION
Hi,

Just a small change: We were seeing respond_to bomb our app for static routes if they have no file extensions. (We are serving up videos via /videos/someassetID) This seems to fix that problem without any big repercussions. I can go into more detail on the problem if you like, though the presented fix doesn't seem to be too intrusive or cause any problems.

Best,
Michael
