### PR TITLE
Fixed the :format respond_to issue

### DIFF
--- a/lib/sinatra/respond_to.rb
+++ b/lib/sinatra/respond_to.rb
@@ -39,8 +39,9 @@ module Sinatra
         unless options.static? && options.public? && (request.get? || request.head?) && static_file?(request.path_info)
           if request.params.has_key? 'format'
             format params['format']
-          else      
-            [:path_info, :route].each { |attr| request.send(attr).sub! %r{\.([^\./]+)$}, '' }
+          else          
+            path_info = request.path_info.sub %r{\.([^\./]+)$}, '' }
+            request.path_info = path_info
             format request.xhr? && options.assume_xhr_is_js? ? :js : $1 || options.default_content
           end
         end

--- a/lib/sinatra/respond_to.rb
+++ b/lib/sinatra/respond_to.rb
@@ -39,9 +39,8 @@ module Sinatra
         unless options.static? && options.public? && (request.get? || request.head?) && static_file?(request.path_info)
           if request.params.has_key? 'format'
             format params['format']
-          else
-            request.path_info.sub! %r{\.([^\./]+)$}, ''
-
+          else      
+            [:path_info, :route].each { |attr| request.send(attr).sub! %r{\.([^\./]+)$}, '' }
             format request.xhr? && options.assume_xhr_is_js? ? :js : $1 || options.default_content
           end
         end

--- a/lib/sinatra/respond_to.rb
+++ b/lib/sinatra/respond_to.rb
@@ -40,8 +40,9 @@ module Sinatra
           if request.params.has_key? 'format'
             format params['format']
           else          
-            path_info = request.path_info.sub %r{\.([^\./]+)$}, '' }
-            request.path_info = path_info
+            request.path_info.sub! %r{\.([^\./]+)$}, ''
+            request.route.sub! %r{\.([^\./]+)$}, ''
+            # request.path_info = path_info
             format request.xhr? && options.assume_xhr_is_js? ? :js : $1 || options.default_content
           end
         end

--- a/lib/sinatra/respond_to.rb
+++ b/lib/sinatra/respond_to.rb
@@ -16,7 +16,7 @@ module Sinatra
       def code; 500 end
     end
 
-    def self.registered(app)
+    def self.registered(app) 
       app.helpers RespondTo::Helpers
 
       app.set :default_content, :html
@@ -32,20 +32,15 @@ module Sinatra
       #   get '/resource'
       #
       # and the format will automatically be available in <tt>format</tt>
-      app.before do                                    
-        puts "DOING RESPOND_TO BEFORE..."
+      app.before do
         # Let through sinatra image urls in development
         next if self.class.development? && request.path_info =~ %r{/__sinatra__/.*?.png}
 
         unless options.static? && options.public? && (request.get? || request.head?) && static_file?(request.path_info)
-          puts "DOING RESPOND_TO BEFORE: #{params['format']}..."
           if request.params.has_key? 'format'
             format params['format']
           else                                              
-            puts "DOING PATH MODS..."
-            request.path_info.sub! %r{\.([^\./]+)$}, ''
-            request.route.sub! %r{\.([^\./]+)$}, ''
-            
+            request.path_info = request.path_info.sub %r{\.([^\./]+)$}, ''
             format request.xhr? && options.assume_xhr_is_js? ? :js : $1 || options.default_content
           end
         end

--- a/lib/sinatra/respond_to.rb
+++ b/lib/sinatra/respond_to.rb
@@ -32,17 +32,20 @@ module Sinatra
       #   get '/resource'
       #
       # and the format will automatically be available in <tt>format</tt>
-      app.before do
+      app.before do                                    
+        puts "DOING RESPOND_TO BEFORE..."
         # Let through sinatra image urls in development
         next if self.class.development? && request.path_info =~ %r{/__sinatra__/.*?.png}
 
         unless options.static? && options.public? && (request.get? || request.head?) && static_file?(request.path_info)
+          puts "DOING RESPOND_TO BEFORE: #{params['format']}..."
           if request.params.has_key? 'format'
             format params['format']
-          else          
+          else                                              
+            puts "DOING PATH MODS..."
             request.path_info.sub! %r{\.([^\./]+)$}, ''
             request.route.sub! %r{\.([^\./]+)$}, ''
-            # request.path_info = path_info
+            
             format request.xhr? && options.assume_xhr_is_js? ? :js : $1 || options.default_content
           end
         end


### PR DESCRIPTION
The respond_to wasn't working with sinatra 1.1.2.  Setter on path_info must be set in order to modify route delayed method which is used by sinatra for routing.
