### PR TITLE
Fix the logic for setting content-type on XHR requests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require 'rubygems'
 require 'bundler'
 Bundler::GemHelper.install_tasks
 

--- a/lib/sinatra/respond_to.rb
+++ b/lib/sinatra/respond_to.rb
@@ -42,7 +42,7 @@ module Sinatra
           else
             request.path_info.sub! %r{\.([^\./]+)$}, ''
 
-            format request.xhr? && options.assume_xhr_is_js? ? :js : $1 || options.default_content
+            format $1 || (request.xhr? && options.assume_xhr_is_js? ? :js : options.default_content)
           end
         end
       end

--- a/spec/extension_spec.rb
+++ b/spec/extension_spec.rb
@@ -34,6 +34,14 @@ describe Sinatra::RespondTo do
       # Put back the option, no side effects here
       TestApp.enable :assume_xhr_is_js
     end
+    
+    it "should not set the content type to application/javascript for an XMLHttpRequest to an explicit extension" do
+      header 'X_REQUESTED_WITH', 'XMLHttpRequest'
+      
+      get '/resource.json'
+      
+      last_response['Content-Type'].should =~ %r{#{mime_type(:json)}}
+    end
   end
 
   describe "extension routing" do


### PR DESCRIPTION
The current logic is that _any_ XHR request wants javascript back, regardless of what the request extension might be (unless you turn off assume_xhr_is_js, of course).  This branch fixes this so that the default :js is only applied to requests to paths without an explicit extension.  This maintains the principle of least-surprise.
