### PR TITLE
Alternate implementation to solve stack level too deep errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,40 +1,45 @@
 PATH
   remote: .
   specs:
-    sinatra-respond_to (0.8.0)
-      sinatra (~> 1.2)
+    ajsharp-sinatra-respond_to (0.8.0)
+      sinatra (~> 1.3)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    builder (2.1.2)
-    diff-lcs (1.1.2)
-    haml (3.0.22)
-    rack (1.2.1)
-    rack-test (0.5.6)
+    builder (3.0.0)
+    diff-lcs (1.1.3)
+    haml (3.1.3)
+    rack (1.3.5)
+    rack-protection (1.1.4)
+      rack
+    rack-test (0.5.7)
       rack (>= 1.0)
-    rcov (0.9.9)
+    rake (0.9.2.2)
+    rcov (0.9.11)
     rspec (2.5.0)
       rspec-core (~> 2.5.0)
       rspec-expectations (~> 2.5.0)
       rspec-mocks (~> 2.5.0)
-    rspec-core (2.5.1)
+    rspec-core (2.5.2)
     rspec-expectations (2.5.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.5.0)
-    sinatra (1.2.6)
-      rack (~> 1.1)
-      tilt (>= 1.2.2, < 2.0)
+    sinatra (1.3.1)
+      rack (~> 1.3, >= 1.3.4)
+      rack-protection (~> 1.1, >= 1.1.2)
+      tilt (~> 1.3, >= 1.3.3)
     tilt (1.3.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  ajsharp-sinatra-respond_to!
   builder (>= 2.0)
   bundler (~> 1.0.10)
   haml (>= 3.0)
   rack-test (~> 0.5.6)
+  rake
   rcov (~> 0.9.8)
   rspec (~> 2.5.0)
-  sinatra-respond_to!

--- a/lib/sinatra/respond_to/version.rb
+++ b/lib/sinatra/respond_to/version.rb
@@ -1,5 +1,5 @@
 module Sinatra
   module RespondTo
-    Version = '0.7.0'
+    Version = '0.7.1'
   end
 end

--- a/sinatra-respond_to.gemspec
+++ b/sinatra-respond_to.gemspec
@@ -5,14 +5,14 @@ Gem::Specification.new do |s|
   s.name        = 'ajsharp-sinatra-respond_to'
   s.version     = Sinatra::RespondTo::Version
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ['Chris Hoffman']
+  s.authors     = ['Alex Sharp', 'Chris Hoffman']
   s.email       = ['cehoffman@gmail.com']
   s.homepage    = 'http://github.com/cehoffman/sinatra-respond_to'
   s.summary     = 'A respond_to style Rails block for baked-in web service support in Sinatra'
 
   s.required_rubygems_version = '>= 1.3.6'
 
-  s.add_runtime_dependency 'sinatra', '~> 1.2'
+  s.add_runtime_dependency 'sinatra', '~> 1.3'
 
   s.add_development_dependency 'rspec', '~> 2.5.0'
   s.add_development_dependency 'rack-test', '~> 0.5.6'
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'builder', '>= 2.0'
   s.add_development_dependency 'haml', '>= 3.0'
   s.add_development_dependency 'bundler', '~> 1.0.10'
+  s.add_development_dependency 'rake'
 
   s.files        = `git ls-files`.split("\n")
   s.test_files   = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/sinatra-respond_to.gemspec
+++ b/sinatra-respond_to.gemspec
@@ -2,7 +2,7 @@
 require File.expand_path('../lib/sinatra/respond_to/version', __FILE__)
 
 Gem::Specification.new do |s|
-  s.name        = 'sinatra-respond_to'
+  s.name        = 'ajsharp-sinatra-respond_to'
   s.version     = Sinatra::RespondTo::Version
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Chris Hoffman']


### PR DESCRIPTION
Method aliasing is subject to a stack level too deep error when code is loaded twice. This implementation avoids that problem by using module inclustion, which allows us to call super() to call the original method.

This article explains the problem: http://blog.jayfields.com/2008/04/alternatives-for-redefining-methods.html
