### PR TITLE
Use Accept header and updates Accept header

### DIFF
--- a/lib/sinatra/respond_to.rb
+++ b/lib/sinatra/respond_to.rb
@@ -42,7 +42,8 @@ module Sinatra
 
             # Rewrite the accept header with the determined format to allow
             # downstream middleware to make use the the mime type
-            request.accept.replace [::Sinatra::Base.mime_type(format)]
+            env['HTTP_ACCEPT'] = ::Sinatra::Base.mime_type(format)
+            request.accept.replace [env['HTTP_ACCEPT']]
           else
             # Consider first Accept type as default, otherwise
             # fall back to settings.default_content
@@ -67,7 +68,8 @@ module Sinatra
 
               # Rewrite the accept header with the determined format to allow
               # downstream middleware to make use the the mime type
-              request.accept.replace [::Sinatra::Base.mime_type(format)]
+              env['HTTP_ACCEPT'] = ::Sinatra::Base.mime_type(format)
+              request.accept.replace [env['HTTP_ACCEPT']]
             else
               format(request.xhr? && settings.assume_xhr_is_js? ? :js : default_content)
             end

--- a/lib/sinatra/respond_to.rb
+++ b/lib/sinatra/respond_to.rb
@@ -39,6 +39,10 @@ module Sinatra
         unless settings.static? && settings.public_folder? && (request.get? || request.head?) && static_file?(request.path_info)
           if request.params.has_key? 'format'
             format params['format']
+
+            # Rewrite the accept header with the determined format to allow
+            # downstream middleware to make use the the mime type
+            request.accept.unshift ::Sinatra::Base.mime_type(format)
           else
             # Consider first Accept type as default, otherwise
             # fall back to settings.default_content

--- a/spec/extension_spec.rb
+++ b/spec/extension_spec.rb
@@ -134,6 +134,31 @@ describe Sinatra::RespondTo do
     end
   end
 
+  describe "accept routing" do
+    it "should use a format parameter before sniffing out the accept header" do
+      get "/resource?format=xml", {'HTTP_ACCEPT' => "text/html"}
+      last_response.body.should =~ %r{\s*<root>Some XML</root>\s*}
+    end
+
+    it "should use an extension before sniffing out the accept header" do
+      get "/resource.xml", {'HTTP_ACCEPT' => "text/html"}
+
+      last_response.body.should =~ %r{\s*<root>Some XML</root>\s*}
+    end
+
+    it "should render for a template using builder" do
+      get "/resource", {'HTTP_ACCEPT' => "application/xml"}
+
+      last_response.body.should =~ %r{\s*<root>Some XML</root>\s*}
+    end
+
+    it "should render for a template using erb" do
+      get "/resource", {'HTTP_ACCEPT' => "application/javascript"}
+
+      last_response.body.should =~ %r{'Hiya from javascript'}
+    end
+  end
+
   describe "routes not using respond_to" do
     it "should set the default content type when no extension" do
       get "/normal-no-respond_to"

--- a/spec/extension_spec.rb
+++ b/spec/extension_spec.rb
@@ -136,24 +136,25 @@ describe Sinatra::RespondTo do
 
   describe "accept routing" do
     it "should use a format parameter before sniffing out the accept header" do
-      get "/resource?format=xml", {'HTTP_ACCEPT' => "text/html"}
+      get "/resource?format=xml", {}, {'HTTP_ACCEPT' => "text/html"}
       last_response.body.should =~ %r{\s*<root>Some XML</root>\s*}
     end
 
     it "should use an extension before sniffing out the accept header" do
-      get "/resource.xml", {'HTTP_ACCEPT' => "text/html"}
+      get "/resource.xml", {}, {'HTTP_ACCEPT' => "text/html"}
 
       last_response.body.should =~ %r{\s*<root>Some XML</root>\s*}
     end
 
     it "should render for a template using builder" do
-      get "/resource", {'HTTP_ACCEPT' => "application/xml"}
+      Rack::Mime::MIME_TYPES[".xsl"] = "application/xsl+xml"  # Mapped poorly in Rack
+      get "/resource", {}, {'HTTP_ACCEPT' => "application/xml"}
 
       last_response.body.should =~ %r{\s*<root>Some XML</root>\s*}
     end
 
     it "should render for a template using erb" do
-      get "/resource", {'HTTP_ACCEPT' => "application/javascript"}
+      get "/resource", {}, {'HTTP_ACCEPT' => "application/javascript"}
 
       last_response.body.should =~ %r{'Hiya from javascript'}
     end

--- a/spec/extension_spec.rb
+++ b/spec/extension_spec.rb
@@ -48,6 +48,8 @@ describe Sinatra::RespondTo do
     it "should use a format parameter before sniffing out the extension" do
       get "/resource?format=xml"
       last_response.body.should =~ %r{\s*<root>Some XML</root>\s*}
+      last_response.content_type.should include(mime_type(:xml))
+      last_request.env['HTTP_ACCEPT'].should == mime_type(:xml)
     end
 
     it "breaks routes expecting an extension" do
@@ -61,24 +63,31 @@ describe Sinatra::RespondTo do
       get "/resource"
 
       last_response.body.should =~ %r{\s*<html>\s*<body>Hello from HTML</body>\s*</html>\s*}
+      last_response.content_type.should include(mime_type(:html))
     end
 
     it "should render for a template using builder" do
       get "/resource.xml"
 
       last_response.body.should =~ %r{\s*<root>Some XML</root>\s*}
+      last_response.content_type.should include(mime_type(:xml))
+      last_request.env['HTTP_ACCEPT'].should == mime_type(:xml)
     end
 
     it "should render for a template using erb" do
       get "/resource.js"
 
       last_response.body.should =~ %r{'Hiya from javascript'}
+      last_response.content_type.should include(mime_type(:js))
+      last_request.env['HTTP_ACCEPT'].should == mime_type(:js)
     end
 
     it "should return string literals in block" do
       get "/resource.json"
 
       last_response.body.should =~ %r{We got some json}
+      last_response.content_type.should include(mime_type(:json))
+      last_request.env['HTTP_ACCEPT'].should == mime_type(:json)
     end
 
     # This will fail if the above is failing
@@ -138,36 +147,44 @@ describe Sinatra::RespondTo do
     it "should use a format parameter before sniffing out the accept header" do
       get "/resource?format=xml", {}, {'HTTP_ACCEPT' => "text/html"}
       last_response.body.should =~ %r{\s*<root>Some XML</root>\s*}
+      last_response.content_type.should include(mime_type(:xml))
+      last_request.env['HTTP_ACCEPT'].should == mime_type(:xml)
     end
 
     it "should use an extension before sniffing out the accept header" do
       get "/resource.xml", {}, {'HTTP_ACCEPT' => "text/html"}
 
       last_response.body.should =~ %r{\s*<root>Some XML</root>\s*}
+      last_response.content_type.should include(mime_type(:xml))
+      last_request.env['HTTP_ACCEPT'].should == mime_type(:xml)
     end
 
     it "should render for a template using builder" do
       get "/resource", {}, {'HTTP_ACCEPT' => "application/xml"}
 
       last_response.body.should =~ %r{\s*<root>Some XML</root>\s*}
+      last_response.content_type.should include(mime_type(:xml))
     end
 
     it "should render for a template using haml" do
       get "/resource", {}, {'HTTP_ACCEPT' => "text/html"}
 
       last_response.body.should =~ %r{\s*<html>\s*<body>Hello from HTML</body>\s*</html>\s*}
+      last_response.content_type.should include(mime_type(:html))
     end
 
     it "should render for a template using json" do
       get "/resource", {}, {'HTTP_ACCEPT' => "application/json"}
 
       last_response.body.should =~ %r{We got some json}
+      last_response.content_type.should include(mime_type(:json))
     end
 
     it "should render for a template using erb" do
       get "/resource", {}, {'HTTP_ACCEPT' => "application/javascript"}
 
       last_response.body.should =~ %r{'Hiya from javascript'}
+      last_response.content_type.should include(mime_type(:js))
     end
   end
 

--- a/spec/extension_spec.rb
+++ b/spec/extension_spec.rb
@@ -147,10 +147,21 @@ describe Sinatra::RespondTo do
     end
 
     it "should render for a template using builder" do
-      Rack::Mime::MIME_TYPES[".xsl"] = "application/xsl+xml"  # Mapped poorly in Rack
       get "/resource", {}, {'HTTP_ACCEPT' => "application/xml"}
 
       last_response.body.should =~ %r{\s*<root>Some XML</root>\s*}
+    end
+
+    it "should render for a template using haml" do
+      get "/resource", {}, {'HTTP_ACCEPT' => "text/html"}
+
+      last_response.body.should =~ %r{\s*<html>\s*<body>Hello from HTML</body>\s*</html>\s*}
+    end
+
+    it "should render for a template using json" do
+      get "/resource", {}, {'HTTP_ACCEPT' => "application/json"}
+
+      last_response.body.should =~ %r{We got some json}
     end
 
     it "should render for a template using erb" do


### PR DESCRIPTION
Basically, the existing gem pretty much defaults to using the specified default_content instead of looking at the Accept header for matches. This update chooses a format based on what's in the accept header, and will match a format in the respond_to block using ordered Accept headers in addition to the detected format.

Identifying a format using the format query parameter or URI extension also modifies the Accept header (Sinatra and environment) to that other middleware can make use of this for proper output formatting.
