### PR TITLE
Fallback to default_content if wildcard present in Accept header

### DIFF
--- a/lib/sinatra/respond_to.rb
+++ b/lib/sinatra/respond_to.rb
@@ -215,7 +215,11 @@ module Sinatra
           request.accept.each do |mime_type|
             break if alt = wants.keys.detect {|k| ::Sinatra::Base.mime_type(k) == mime_type}
           end
-          format alt if alt
+          if alt
+            format alt
+          elsif request.accept.include?("*.*")
+            format settings.default_content
+          end
         end
         raise UnhandledFormat  if wants[format].nil?
         wants[format].call

--- a/spec/extension_spec.rb
+++ b/spec/extension_spec.rb
@@ -186,6 +186,12 @@ describe Sinatra::RespondTo do
       last_response.body.should =~ %r{'Hiya from javascript'}
       last_response.content_type.should include(mime_type(:js))
     end
+
+    it "should use default_content when the first Accept header includes the wildcard" do
+      get "/resource", {}, {'HTTP_ACCEPT' => "text/csv;q=0.9,*.*;q=0.8"}
+      last_response.body.should =~ %r{\s*<html>\s*<body>Hello from HTML</body>\s*</html>\s*}
+      last_response.content_type.should include(mime_type(:html))
+    end
   end
 
   describe "routes not using respond_to" do


### PR DESCRIPTION
If a browser makes a request like this:

```
Accept: text/csv,*.*
```

And the application is implemented like this:

```
set :default_content, :html

get "/" do
  respond_to do |wants|
    format.html { erb :home }
  end
end
```

The request would return a 404, even though the caller specifically said
it was ready to accept any mime type.

I found this when building an API that does not return HTML: it returns
JSON or CSV, but browsers request HTML, XHTML and _/_, in this order. By
catering to what the caller asked for, the API is more easily explorable
in a browser.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cehoffman/sinatra-respond_to/21)
<!-- Reviewable:end -->
